### PR TITLE
fix(ci): Download FFmpeg to resolve Windows test failures

### DIFF
--- a/dialogue-guardian/.gitignore
+++ b/dialogue-guardian/.gitignore
@@ -1,0 +1,2 @@
+# Ignore downloaded binaries
+/bin/

--- a/dialogue-guardian/dev-requirements.txt
+++ b/dialogue-guardian/dev-requirements.txt
@@ -1,4 +1,6 @@
 # Development dependencies
+requests>=2.25.1
+py7zr>=0.16.1
 srt>=3.5.0
 pytest>=6.0.0
 pytest-cov>=2.10.0

--- a/dialogue-guardian/tests/conftest.py
+++ b/dialogue-guardian/tests/conftest.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 Tony Snearly
+# SPDX-License-Identifier: OSL-3.0
+"""
+Pytest configuration and fixtures.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def download_ffmpeg_fixture(request):
+    """
+    Fixture to run the FFmpeg download script before any tests run.
+    This is a session-scoped fixture that runs automatically.
+    """
+    # Only run this on the master node in a distributed testing environment
+    if not hasattr(request.config, "workerinput"):
+        script_path = Path(__file__).parent.parent / "scripts" / "download_ffmpeg.py"
+        print(f"\nRunning FFmpeg download script: {script_path}")
+
+        # Use the same Python executable that is running pytest
+        python_executable = sys.executable
+        result = subprocess.run(
+            [python_executable, str(script_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        if "skipping download" not in result.stdout.lower():
+            print("--- FFmpeg Download Script STDOUT ---")
+            print(result.stdout)
+
+        if result.returncode != 0:
+            print("--- FFmpeg Download Script STDERR ---")
+            print(result.stderr)
+            pytest.fail(
+                "The FFmpeg download script failed. Halting tests.", pytrace=False
+            )
+
+        print("FFmpeg setup is complete.")

--- a/dialogue-guardian/tests/test_guardian_core.py
+++ b/dialogue-guardian/tests/test_guardian_core.py
@@ -5,8 +5,10 @@
 Unit tests for guardian.core module
 """
 
+import platform
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import mock_open, patch
 
 import srt
@@ -36,8 +38,24 @@ class TestGuardianProcessor(unittest.TestCase):
         self.assertEqual(
             processor.matching_words, GuardianProcessor.DEFAULT_MATCHING_WORDS
         )
-        self.assertEqual(processor.ffmpeg_cmd, "ffmpeg")
-        self.assertEqual(processor.ffprobe_cmd, "ffprobe")
+
+        # Check if local binaries exist and adjust assertions accordingly
+        bin_dir = Path(__file__).parent.parent / "bin"
+        ffmpeg_exe = "ffmpeg.exe" if platform.system() == "Windows" else "ffmpeg"
+        ffprobe_exe = "ffprobe.exe" if platform.system() == "Windows" else "ffprobe"
+
+        local_ffmpeg_path = bin_dir / ffmpeg_exe
+        local_ffprobe_path = bin_dir / ffprobe_exe
+
+        if local_ffmpeg_path.is_file():
+            self.assertEqual(processor.ffmpeg_cmd, str(local_ffmpeg_path))
+        else:
+            self.assertEqual(processor.ffmpeg_cmd, "ffmpeg")
+
+        if local_ffprobe_path.is_file():
+            self.assertEqual(processor.ffprobe_cmd, str(local_ffprobe_path))
+        else:
+            self.assertEqual(processor.ffprobe_cmd, "ffprobe")
 
     def test_init_custom_values(self):
         """Test processor initialization with custom values"""

--- a/dialogue-guardian/tests/test_guardian_integration.py
+++ b/dialogue-guardian/tests/test_guardian_integration.py
@@ -365,12 +365,19 @@ class TestGuardianIntegration(unittest.TestCase):
 
     def test_custom_ffmpeg_paths(self):
         """Test processor with custom FFmpeg paths"""
-        processor = GuardianProcessor(
+        # Test with custom paths
+        processor_custom = GuardianProcessor(
             ffmpeg_cmd="/custom/ffmpeg", ffprobe_cmd="/custom/ffprobe"
         )
+        self.assertEqual(processor_custom.ffmpeg_cmd, "/custom/ffmpeg")
+        self.assertEqual(processor_custom.ffprobe_cmd, "/custom/ffprobe")
 
-        self.assertEqual(processor.ffmpeg_cmd, "/custom/ffmpeg")
-        self.assertEqual(processor.ffprobe_cmd, "/custom/ffprobe")
+        # Test that it falls back to system path if local is not found
+        # and no custom path is provided.
+        with patch("pathlib.Path.is_file", return_value=False):
+            processor_default = GuardianProcessor(ffmpeg_cmd=None, ffprobe_cmd=None)
+            self.assertEqual(processor_default.ffmpeg_cmd, "ffmpeg")
+            self.assertEqual(processor_default.ffprobe_cmd, "ffprobe")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The Windows CI build was failing because FFmpeg and ffprobe were not available in the test environment.

This change introduces a script to automatically download the correct FFmpeg binaries for the host OS (Windows, macOS, or Linux) into a local `bin/` directory. A pytest fixture in `conftest.py` ensures this script runs before the test suite.

The `GuardianProcessor` is updated to look for the executables in this local `bin/` directory before falling back to the system's PATH. This makes the project more portable and simplifies setup for both CI and local development.

The `bin/` directory is added to `.gitignore` to prevent the large binary files from being committed to the repository.